### PR TITLE
Fix Abstract2 ordering

### DIFF
--- a/Analysis/Abstract2.h
+++ b/Analysis/Abstract2.h
@@ -19,26 +19,34 @@ struct Abstract2 {
 	Abstract2(const Abstract1 &_vars,const Abstract1 &_guards) : vars(_vars), guards(_guards) { }
 	virtual ~Abstract2() { }
 
-	bool operator<(const Abstract2& left) const {
-		assert(vars.abstract() && left.vars.abstract());
-		environment env = vars.abstract()->get_environment();
-		if (env != left.vars.abstract()->get_environment()) {
-			vector<var> vv = left.vars.abstract()->get_environment().get_vars();
+	bool operator<(const Abstract2& right) const {
+		assert(vars.abstract() && right.vars.abstract());
+		environment vars_env = vars.abstract()->get_environment();
+		environment guards_env = guards.abstract()->get_environment();
+		abstract1 vars_abs1 = *vars.abstract(), vars_abs2 = *right.vars.abstract();
+		abstract1 guards_abs1 = *guards.abstract(), guards_abs2 = *right.guards.abstract();
+		if (vars_env != right.vars.abstract()->get_environment()) {
+			vector<var> vv = right.vars.abstract()->get_environment().get_vars();
 			for (int i = 0;i < vv.size();++i)
-				if (!env.contains(vv[i]))
-					env.add(&vv[i],1,0,0);
+				if (!vars_env.contains(vv[i]))
+					vars_env.add(&vv[i],1,0,0);
 			manager mgr = vars.abstract()->get_manager();
-			abstract1 abs1 = *vars.abstract(), abs2 = *left.vars.abstract();
-			abs1 = abs1.change_environment(mgr,env);
-			abs2 = abs2.change_environment(mgr,env);
-			return (abs1 < abs2);
+			vars_abs1 = vars_abs1.change_environment(mgr,vars_env);
+			vars_abs2 = vars_abs2.change_environment(mgr,vars_env);
 		}
-		return *vars.abstract() < *left.vars.abstract();
+		if (guards_env != right.guards.abstract()->get_environment()) {
+			vector<var> vv = right.guards.abstract()->get_environment().get_vars();
+			for (int i = 0;i < vv.size();++i)
+				if (!guards_env.contains(vv[i]))
+					guards_env.add(&vv[i],1,0,0);
+			manager mgr = guards.abstract()->get_manager();
+			guards_abs1 = guards_abs1.change_environment(mgr,guards_env);
+			guards_abs2 = guards_abs2.change_environment(mgr,guards_env);
+		}
+
+		return ((vars_abs1 < vars_abs2) || (!(vars_abs1 > vars_abs2) && guards_abs1 < guards_abs2));
 	}
-	/*
-	bool operator<(const Abstract2& left) const { return vars.key()+guards.key() < left.vars.key()+left.guards.key(); }
-	bool operator>(const Abstract2& left) const { return vars.key()+guards.key() > left.vars.key()+left.guards.key(); }
-	*/
+
 	friend ostream& operator<<(ostream& os, const Abstract2& abstract ) {
 		os << abstract.guards << " <-> " << abstract.vars;
 		return os;


### PR DESCRIPTION
Abstract2 ordering (operator <) was defined as the ordering on the abstract
interpretation for the variables alone, not taking the guards into account at
all.

Therefore, two Abstract2 values with the same interpretation for variables but
different interpretations for guards were considered equal, thus losing subsets
sharing the same interpretation for variables when building AbstractSet values.