### PR TITLE
Improve/fix array/pointer support in dizy

### DIFF
--- a/Analysis/TransferFuncs.cpp
+++ b/Analysis/TransferFuncs.cpp
@@ -658,7 +658,9 @@ ExpressionState TransferFuncs::VisitDeclStmt(DeclStmt* node) {
 				}
 			}
 
-			if ( decl->getType().getTypePtr()->isIntegerType() ) { // apply to integers alone (this includes guards)
+			else if ( decl->getType().getTypePtr()->isIntegerType()
+				 || (decl->getType().getTypePtr()->isPointerType() && decl->getType().getTypePtr()->getPointeeType()->isIntegerType()) ) {
+				// apply to integers and pointers (this includes guards)
 				manager mgr = *(state_.mgr_ptr_);
 				var v(name.str());
 				/* first forget the variable (in case its defined in a loop) */


### PR DESCRIPTION
Hi,
There are a few issues preventing dizy from working correctly with arrays.

* The first one is that only integer arguments are considered equal, and not pointer arguments.
Thus, dizy cannot infer any meaningful relation between accesses of the same input array in the original and modified version of the program, thus badly affecting dizy's precision when one of the input parameters is a pointer. This is fixed in the first commit by extending initial value handling to pointer values, as it is done in SCORE.

* The second issue is that only pointer values are considered arrays. However, LLVM distinguishes between pointer values and arrays. This leads to various issues affecting both precision and soundness. This is addressed in the second commit.

On a side note, “ccc” may produce incorrect correlating programs by aliasing pointers from the original version and the modified version together. While it might be mitigated by dizy's rules (I haven't checked yet), it is still a fundamental issue with “ccc”. This is not a fundamental problem with SCORE (I haven't checked how the implementation handles it, though).